### PR TITLE
Add the prefer-stable setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,6 @@
       "Noweh\\SoundcloudApi\\": "src/"
     }
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }


### PR DESCRIPTION
# Changed log

- As title. Once adding this setting, it will install stable dependencies when setting `minimum-stability` is `dev`.
- If above setting is not configured, it will install development dependencies.